### PR TITLE
Fix team-chest blacklist

### DIFF
--- a/mods/ctf_team_base/chest.lua
+++ b/mods/ctf_team_base/chest.lua
@@ -129,7 +129,7 @@ for _, chest_color in pairs(colors) do
 				return 0
 			end
 
-			for itemstring in ipairs(blacklist) do
+			for _, itemstring in ipairs(blacklist) do
 				if stack:get_name() == itemstring then
 					return 0
 				end


### PR DESCRIPTION
fix typo in the ipair loop so it checks the string not the index of the blacklist table